### PR TITLE
Add rate limiting to API routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   },
   "homepage": "https://github.com/j3d1h4x0r/MASTERBOT#readme",
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-rate-limit": "^6.7.0"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"

--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const path = require('path');
+const rateLimit = require('express-rate-limit');
 const RaspberryPiController = require('./index');
 const config = require('./config.json');
 
@@ -17,6 +18,15 @@ app.use((req, res, next) => {
     }
     next();
 });
+
+// Rate limiting for API routes
+if (config.api.rate_limit && config.api.rate_limit.enabled) {
+    const limiter = rateLimit({
+        windowMs: 60 * 1000, // 1 minute
+        max: config.api.rate_limit.requests_per_minute
+    });
+    app.use('/api', limiter);
+}
 
 // Basic authentication middleware
 function basicAuth(req, res, next) {


### PR DESCRIPTION
## Summary
- include `express-rate-limit` dependency
- enable API rate limiter via `config.api.rate_limit`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684fda1cad6083249309410e4314943d