### PR TITLE
Add environment-based auth overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ MASTERBOT is a comprehensive Raspberry Pi controller designed specifically for t
    - **Username**: admin
    - **Password**: changeMe123!
 
+   You can override these credentials using environment variables before starting the server:
+
+   ```bash
+   WEB_USER=myuser WEB_PASS=mypass npm start
+   ```
+
 ### Command Line Interface
 
 ```bash
@@ -120,7 +126,7 @@ Edit `config.json` to customize your setup:
   "web_interface": {
     "enabled": true,
     "port": 3000,
-    "auth": {
+  "auth": {
       "enabled": true,
       "username": "admin",
       "password": "changeMe123!"
@@ -128,6 +134,8 @@ Edit `config.json` to customize your setup:
   }
 }
 ```
+
+The `WEB_USER` and `WEB_PASS` environment variables can be set to override the `username` and `password` values when launching the server.
 
 ## 🏗️ Project Structure
 

--- a/server.js
+++ b/server.js
@@ -3,6 +3,10 @@ const path = require('path');
 const RaspberryPiController = require('./index');
 const config = require('./config.json');
 
+// Allow environment variables to override configured credentials
+const AUTH_USER = process.env.WEB_USER || config.web_interface.auth.username;
+const AUTH_PASS = process.env.WEB_PASS || config.web_interface.auth.password;
+
 const app = express();
 const controller = new RaspberryPiController();
 
@@ -34,7 +38,10 @@ function basicAuth(req, res, next) {
     const username = credentials[0];
     const password = credentials[1];
 
-    if (username === config.web_interface.auth.username && password === config.web_interface.auth.password) {
+    const expectedUser = process.env.WEB_USER || config.web_interface.auth.username;
+    const expectedPass = process.env.WEB_PASS || config.web_interface.auth.password;
+
+    if (username === expectedUser && password === expectedPass) {
         next();
     } else {
         res.status(401).json({ error: 'Invalid credentials' });
@@ -179,7 +186,7 @@ app.listen(PORT, HOST, () => {
     console.log(`🔧 API available on http://${HOST}:${PORT}/api`);
     console.log(`💡 Access the dashboard at http://${HOST}:${PORT}`);
     if (config.web_interface.auth.enabled) {
-        console.log(`🔐 Authentication enabled - Username: ${config.web_interface.auth.username}`);
+        console.log(`🔐 Authentication enabled - Username: ${AUTH_USER}`);
     }
 });
 


### PR DESCRIPTION
## Summary
- allow basicAuth middleware to read WEB_USER/WEB_PASS env vars
- log active auth username at startup
- document authentication overrides in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684fda2a026c83248f343814c8b63a85