### PR TITLE
Add separate API server

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ npm start
 # Visit http://localhost:3000
 
 # Test API endpoints
-curl -u admin:changeMe123! http://localhost:3000/api/system/info
+curl -u admin:changeMe123! http://localhost:3001/api/system/info
 ```
 
 ## 🤝 Contributing


### PR DESCRIPTION
## Summary
- host main dashboard on `web_interface.port`
- expose REST API from a new Express instance when enabled
- update example API curl command

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684fda2c8d9c832494b57b99f9927b1d